### PR TITLE
Bump phoenix to 0.17

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,9 +28,9 @@ defmodule ElixirJobs.Mixfile do
   #
   # Type `mix help deps` for examples and options
   defp deps do
-    [{:phoenix, "~> 0.16"},
+    [{:phoenix, "~> 0.17"},
      {:phoenix_html, "~> 2.0"},
-     {:phoenix_live_reload, "~> 0.5", only: :dev},
+     {:phoenix_live_reload, "~> 1.0", only: :dev},
      {:cowboy, "~> 1.0"},
      {:exrethinkdb, github: "hamiltop/exrethinkdb", ref: "55fb5b5ed892f28b7ae8ee1b2f8e54fb651bd611"},
      {:timex, "~> 0.13.4"},


### PR DESCRIPTION
upgrade guide (although there seems nothing has to be done here): https://gist.github.com/chrismccord/ee5ae90b949a9768b871
