### PR TITLE
Show the location in the job listing

### DIFF
--- a/web/templates/page/job.html.eex
+++ b/web/templates/page/job.html.eex
@@ -13,6 +13,9 @@
         <%= if @job["job_type"] != "" do %>
         <div class="ui teal horizontal label"><i class="newspaper icon"></i> <%= @job["job_type"] %></div> 
         <% end %>
+        <%= if @job["location"] != "" do %>
+        <div class="ui grey horizontal label"><i class="globe icon"></i> <%= @job["location"] %></div> 
+        <% end %>
       </div>
       <span><%= @job["title"] %></span>
     </a>


### PR DESCRIPTION
I thought it might be useful to simply show the job location in the list of jobs, rather than clicking on all of them to see which are in my part of the world. 
