### PR TITLE
Redirect on login & login after creating account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /db
 /deps
 /*.ez
+*.swp
 
 # Generate on crash by the VM
 erl_crash.dump

--- a/web/controllers/page_controller.ex
+++ b/web/controllers/page_controller.ex
@@ -136,9 +136,12 @@ defmodule ElixirJobs.PageController do
     |> redirect(to: "/")
   end
 
-  defp authenticate(conn, _params) do
+  defp authenticate(conn, params) do
     if is_nil(get_session(conn, :user)) do
-        conn |> put_flash(:error, "You need to login first") |> redirect(to: "/users/login") |> halt
+        conn
+        |> put_flash(:error, "You need to login first")
+        |> put_flash(:redir, conn.request_path)
+        |> redirect(to: "/users/login") |> halt
     else
       conn
     end

--- a/web/templates/user/login.html.eex
+++ b/web/templates/user/login.html.eex
@@ -1,7 +1,7 @@
 <div class="ui segment">
   <div class="ui relaxed grid">
     <div class="eight wide column">
-      <form class="ui form" action="<%= user_path(@conn, :process_login) %>" method="post" data-parsley-validate>
+      <form class="ui form" action="<%= user_path(@conn, :process_login, @flash) %>" method="post" data-parsley-validate>
         <div class="ui dividing blue header">Login</div>
         <input type="hidden" name="_csrf_token" value="<%= get_csrf_token() %>">
         <div class="field">
@@ -21,7 +21,7 @@
       OR
     </div>
     <div class="eight wide column">
-      <form class="ui form" action="<%= user_path(@conn, :create) %>" method="post" data-parsley-validate>
+      <form class="ui form" action="<%= user_path(@conn, :create, @flash) %>" method="post" data-parsley-validate>
         <div class="ui dividing orange header">New User</div>
         <input type="hidden" name="_csrf_token" value="<%= get_csrf_token() %>">
         <div class="field">


### PR DESCRIPTION
If an unauthenticated user selects a job and logs in when prompted
(including via account creation), they will be redirected to the job
they previously attempted to view.
